### PR TITLE
DEVOPS-645 Adding whitelist feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version.
 
+## 0.2.0 / 2016-08-23
+
+### Added
+* Whitelist option - will always return 0 for all priorities when there are no jobs.
+
 ## 0.1.1 / 2016-08-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ instances:
     mysql_database: 'gearmand'
     mysql_table: 'gearman_queue'
     mysql_port: 3306
+    whitelist:
+      - test_queue_one
+      - test_queue_two
 ```
 
 ## Development

--- a/conf.d/gearman_mysql.yaml.example
+++ b/conf.d/gearman_mysql.yaml.example
@@ -7,3 +7,6 @@ instances:
     mysql_database: 'gearmand'
     mysql_table: 'gearman_queue'
     mysql_port: 3306
+    whitelist:
+      - test_queue_one
+      - test_queue_two


### PR DESCRIPTION
Introducing whitelist of metrics, that should always have values reported. By default they'd return 0 meaning no jobs are currently in their queue, but marking, that the queue still exists. This will help with an issue we have right now where DataDog uses last known, non-zero value as current value, where in reality there are no jobs for this queue.
